### PR TITLE
Make Youtube link https

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -50,7 +50,7 @@ a9s RabbitMQ for PCF includes the following key features:
 The following video provides an overview of how a9s RabbitMQ for PCF works.
 
 <p>
-  <iframe src="http://www.youtube.com/embed/yZOI_wQ5eTo"
+  <iframe src="https://www.youtube.com/embed/yZOI_wQ5eTo"
     width="656" height="372" frameborder="0" allowfullscreen></iframe>
 </p>
 


### PR DESCRIPTION
A colleague of mine had a look at the issue with the video on some browsers and is assuming that the issue might come from the *http* link.
I changed this to *https*. Hopefully, this will fix the issue.